### PR TITLE
support spconv2.x

### DIFF
--- a/model/softgroup/softgroup.py
+++ b/model/softgroup/softgroup.py
@@ -1,7 +1,8 @@
 import torch
 import torch.nn as nn
-import spconv
-from spconv.modules import SparseModule
+import spconv.pytorch as spconv
+from spconv.pytorch.modules import SparseModule
+from spconv.core import ConvAlgo
 import functools
 from collections import OrderedDict
 import sys
@@ -10,6 +11,22 @@ sys.path.append('../../')
 from lib.softgroup_ops.functions import softgroup_ops
 from util import utils
 import torch.nn.functional as F
+
+
+# current 1x1 conv in spconv2x has a bug. This is a workaround. It will be removed after the bug is fixed
+class Custom1x1Subm3d(spconv.SparseConv3d):
+
+    def forward(self, input):
+        features = torch.mm(
+            input.features,
+            self.weight.view(self.in_channels, self.out_channels))
+        if self.bias is not None:
+            features += self.bias
+        out_tensor = spconv.SparseConvTensor(features, input.indices,
+                                             input.spatial_shape, input.batch_size)
+        out_tensor.indice_dict = input.indice_dict
+        out_tensor.grid = input.grid
+        return out_tensor
 
 
 class ResidualBlock(SparseModule):
@@ -22,23 +39,23 @@ class ResidualBlock(SparseModule):
             )
         else:
             self.i_branch = spconv.SparseSequential(
-                spconv.SubMConv3d(in_channels, out_channels, kernel_size=1, bias=False)
+                Custom1x1Subm3d(in_channels, out_channels, kernel_size=1, bias=False, algo=ConvAlgo.Native)
             )
 
         self.conv_branch = spconv.SparseSequential(
             norm_fn(in_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key),
+            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key, algo=ConvAlgo.Native),
             norm_fn(out_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(out_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key)
+            spconv.SubMConv3d(out_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key, algo=ConvAlgo.Native)
         )
 
     def forward(self, input):
         identity = spconv.SparseConvTensor(input.features, input.indices, input.spatial_shape, input.batch_size)
         output = self.conv_branch(input)
-        output.features += self.i_branch(identity).features
-
+        out_feats = output.features + self.i_branch(identity).features
+        output = output.replace_feature(out_feats)
         return output
 
 
@@ -49,7 +66,7 @@ class VGGBlock(SparseModule):
         self.conv_layers = spconv.SparseSequential(
             norm_fn(in_channels),
             nn.ReLU(),
-            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key)
+            spconv.SubMConv3d(in_channels, out_channels, kernel_size=3, padding=1, bias=False, indice_key=indice_key, algo=ConvAlgo.Native)
         )
 
     def forward(self, input):
@@ -71,7 +88,7 @@ class UBlock(nn.Module):
             self.conv = spconv.SparseSequential(
                 norm_fn(nPlanes[0]),
                 nn.ReLU(),                                   
-                spconv.SparseConv3d(nPlanes[0], nPlanes[1], kernel_size=2, stride=2, bias=False, indice_key='spconv{}'.format(indice_key_id))
+                spconv.SparseConv3d(nPlanes[0], nPlanes[1], kernel_size=2, stride=2, bias=False, indice_key='spconv{}'.format(indice_key_id), algo=ConvAlgo.Native)
             )
 
             self.u = UBlock(nPlanes[1:], norm_fn, block_reps, block, indice_key_id=indice_key_id+1)
@@ -79,7 +96,7 @@ class UBlock(nn.Module):
             self.deconv = spconv.SparseSequential(
                 norm_fn(nPlanes[1]),
                 nn.ReLU(),                                             
-                spconv.SparseInverseConv3d(nPlanes[1], nPlanes[0], kernel_size=2, bias=False, indice_key='spconv{}'.format(indice_key_id))
+                spconv.SparseInverseConv3d(nPlanes[1], nPlanes[0], kernel_size=2, bias=False, indice_key='spconv{}'.format(indice_key_id), algo=ConvAlgo.Native)
             )
 
             blocks_tail = {}
@@ -96,7 +113,8 @@ class UBlock(nn.Module):
             output_decoder = self.conv(output)
             output_decoder = self.u(output_decoder)
             output_decoder = self.deconv(output_decoder)
-            output.features = torch.cat((identity.features, output_decoder.features), dim=1)
+            out_feats = torch.cat((identity.features, output_decoder.features), dim=1)
+            output = output.replace_feature(out_feats)
             output = self.blocks_tail(output)
         return output
 
@@ -138,7 +156,7 @@ class SoftGroup(nn.Module):
 
         # backbone
         self.input_conv = spconv.SparseSequential(
-            spconv.SubMConv3d(input_c, width, kernel_size=3, padding=1, bias=False, indice_key='subm1')
+            spconv.SubMConv3d(input_c, width, kernel_size=3, padding=1, bias=False, indice_key='subm1', algo=ConvAlgo.Native)
         )
         self.unet = UBlock([width, 2*width, 3*width, 4*width, 5*width, 6*width, 7*width], norm_fn, block_reps, block, indice_key_id=1)
         self.output_layer = spconv.SparseSequential(
@@ -358,7 +376,6 @@ class SoftGroup(nn.Module):
 
                 proposals_idx[:, 1] = object_idxs[proposals_idx[:, 1].long()].int()
 
-                # import pdb; pdb.set_trace()
                 # merge proposals
                 cls_pred = proposals_offset.new_full((proposals_offset.size(0) - 1,), class_id)
                 if len(proposals_offset_list) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-torch==1.1
 cmake>=3.13.2
 plyfile
 tensorboardX


### PR DESCRIPTION
This PR provides support for spconv2.x. When benchmark spconv1.0 model on this PR the result is less than reported result around 1 point (due to spconv/pytorch version changes and some randomness). Retrain the model may address the problem. 

### tested environment:
- cuda 10.2
- pytorch 1.10
- spconv 2.1.21